### PR TITLE
Add basic React example for lock icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# locking-app
+# Locking App
+
+This repository contains a very small React-based web page. When loaded in a browser it shows a white lock icon on a green background.
+
+## Running
+
+Any basic HTTP server can host the page. If you have Python installed, you can run:
+
+```bash
+python3 -m http.server
+```
+
+Then open your browser to <http://localhost:8000> and navigate to `index.html`.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Locking App</title>
+  <style>
+    body, html {
+      margin: 0;
+      padding: 0;
+      height: 100%;
+    }
+    #root {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 100%;
+      background-color: #28a745;
+      color: white;
+      font-family: Arial, sans-serif;
+      text-align: center;
+    }
+    svg {
+      width: 64px;
+      height: 64px;
+      fill: white;
+    }
+  </style>
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js" crossorigin></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel">
+    function LockIcon() {
+      return (
+        <svg viewBox="0 0 24 24">
+          <path d="M12 17a2 2 0 100-4 2 2 0 000 4zm6-7h-1V7a5 5 0 10-10 0v3H6a2 2 0 00-2 2v9a2 2 0 002 2h12a2 2 0 002-2v-9a2 2 0 00-2-2zm-8-3a4 4 0 118 0v3H10V7z" />
+        </svg>
+      );
+    }
+
+    function App() {
+      return (
+        <div>
+          <LockIcon />
+          <h1>Hello, world!</h1>
+        </div>
+      );
+    }
+
+    const root = ReactDOM.createRoot(document.getElementById('root'));
+    root.render(<App />);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple `index.html` that loads React from a CDN and shows a lock icon
- update README with brief usage instructions

## Testing
- `node -v`
