### PR TITLE
Fix redundant register events

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,8 @@ function App() {
   const [unlocked, setUnlocked] = useState(false);
   const [audioEnabled, setAudioEnabled] = useState(false);
   const unlockedAudioRef = useRef(new Audio(unlockedSound));
+  // Track the latest value of audioEnabled for the WebSocket callback
+  const audioEnabledRef = useRef(audioEnabled);
 
   const enableAudio = () => {
     if (unlockedAudioRef.current) {
@@ -28,6 +30,11 @@ function App() {
       setAudioEnabled(true);
     }
   };
+
+  // Keep the ref in sync with the latest audioEnabled state
+  useEffect(() => {
+    audioEnabledRef.current = audioEnabled;
+  }, [audioEnabled]);
 
   useEffect(() => {
     // Generate a simple unique id for this client.
@@ -46,7 +53,7 @@ function App() {
         const data = JSON.parse(evt.data);
         if (data.event === 'unlocked' && data.id === id) {
           setUnlocked(true);
-          if (unlockedAudioRef.current && audioEnabled) {
+          if (unlockedAudioRef.current && audioEnabledRef.current) {
             try {
               console.log('made it');
               unlockedAudioRef.current.play();
@@ -64,7 +71,7 @@ function App() {
     return () => {
       socket.close();
     };
-  }, [audioEnabled]);
+  }, []);
 
   return (
     <div className={`App ${unlocked ? 'unlocked' : ''}`}>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,7 +1,10 @@
 import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import App from './App';
 
 let origWebSocket;
+let playSpy;
+let pauseSpy;
 
 beforeEach(() => {
   origWebSocket = global.WebSocket;
@@ -10,10 +13,14 @@ beforeEach(() => {
     send: jest.fn(),
     close: jest.fn(),
   }));
+  playSpy = jest.spyOn(window.HTMLMediaElement.prototype, 'play').mockImplementation(() => Promise.resolve());
+  pauseSpy = jest.spyOn(window.HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
 });
 
 afterEach(() => {
   global.WebSocket = origWebSocket;
+  playSpy.mockRestore();
+  pauseSpy.mockRestore();
 });
 
 test('renders lock icon', () => {
@@ -57,6 +64,33 @@ test('switches to unlocked icon and background on event', () => {
   expect(icon).toBeInTheDocument();
   const app = document.querySelector('.App.unlocked');
   expect(app).not.toBeNull();
+
+  global.WebSocket = origWebSocket;
+});
+
+test('enabling audio does not re-register with the server', async () => {
+  const listeners = {};
+  const mockSocket = {
+    addEventListener: (event, cb) => {
+      listeners[event] = cb;
+    },
+    send: jest.fn(),
+    close: jest.fn(),
+  };
+  const origWebSocket = global.WebSocket;
+  global.WebSocket = jest.fn(() => mockSocket);
+
+  render(<App />);
+
+  act(() => {
+    listeners['open'] && listeners['open']();
+  });
+
+  expect(mockSocket.send).toHaveBeenCalledTimes(1);
+
+  await userEvent.click(screen.getByRole('button', { name: /enable audio/i }));
+
+  expect(mockSocket.send).toHaveBeenCalledTimes(1);
 
   global.WebSocket = origWebSocket;
 });


### PR DESCRIPTION
## Summary
- ensure websocket connection only registers once
- keep audio state in a ref for websocket callbacks
- test that enabling audio does not re-register

## Testing
- `CI=true npm test --silent`