### PR TITLE
Add user input event registration to lock app

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,9 +1,12 @@
 .App {
-  background-color: red;
+  background-color: #b0c4de; /* grayish blue */
   min-height: 100vh;
   display: flex;
   align-items: center;
   justify-content: center;
+}
+.App.registered {
+  background-color: red;
 }
 .App.unlocked {
   background-color: green;
@@ -23,4 +26,11 @@
   left: 1rem;
   padding: 0.5rem 1rem;
   font-size: 1rem;
+}
+
+.register-form {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
 }


### PR DESCRIPTION
## Summary
- start with a registration form rather than sending register event on load
- show lock icon only after registering
- switch colours using new CSS classes
- update tests for the new behaviour

## Testing
- `CI=true npm test --silent`